### PR TITLE
Stop escaping quotes in CSS

### DIFF
--- a/wds-customizer-css.php
+++ b/wds-customizer-css.php
@@ -86,7 +86,7 @@ if ( ! class_exists( 'WDS_Customizer_CSS' ) ) {
 				check_admin_referer( 'wds_custom_css_nonce' );
 
 				if( isset ( $_POST[ 'wds_custom_css' ] ) ) {
-					set_theme_mod( 'wds_custom_css', strip_tags( $_POST[ 'wds_custom_css' ] ) );
+					set_theme_mod( 'wds_custom_css', strip_tags( stripslashes( $_POST[ 'wds_custom_css' ] ) ) );
 				}
 			}
 


### PR DESCRIPTION
Users might use `content` css property in their Custom CSS as below

```
h1::before  { content: "Chapter "; }
```

If we don't stop escaping quotes before saving the css into database, users will finally get 

```
h1::before  { content: \"Chapter \"; }
```

It's not valid CSS.
